### PR TITLE
Re-init header after fetching entries

### DIFF
--- a/reaper.el
+++ b/reaper.el
@@ -115,7 +115,6 @@
         tabulated-list-entries #'reaper--list-entries
         tabulated-list-padding 3)
   (reaper-refresh-buffer)
-  (tabulated-list-init-header)
   ;; Start a timer to update the running timer.
   (setq reaper-update-timer (run-at-time t 60 #'reaper--update-timer))
   (add-hook 'kill-buffer-hook #'reaper-kill-buffer-hook))
@@ -234,6 +233,7 @@ Will create it if it doesn't exist yet."
   (interactive)
   (unless (bound-and-true-p reaper-timeentries)
     (reaper-refresh-entries))
+  (tabulated-list-init-header)
   (tabulated-list-print t)
   (reaper--highlight-running))
 


### PR DESCRIPTION
Previous display-line-numbers-mode compatibility fix wasn't quite
successful.