### PR TITLE
Add possibility to edit start/end time on entry

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,11 @@ and use Emacs customization interface to set `reaper-api-key` to the
 given value. On the same page at Harvest you should be able to see the
 account id you'll need for `reaper-account-id`.
 
+Harvest supports two timer modes to track time via hours duration and via start and end time.
+Use `reaper-hours-timer-mode` to customize the timer mode.
+Default value is `t` which means hours duration is used to track time.
+Set variable to `nil` if you want to track time via start and end time.
+
 ## Usage
 
 Use `M-x reaper` to open the buffer (or whatever key sequence you've bound it to). 

--- a/reaper.el
+++ b/reaper.el
@@ -189,6 +189,8 @@
                      (cons :task (reaper-alist-get '(task name) entry))
                      (cons :is_running (reaper-alist-get '(is_running) entry))
                      (cons :hours (reaper-alist-get '(hours) entry))
+                     (cons :started_time (reaper-alist-get '(started_time) entry))
+                     (cons :ended_time (reaper-alist-get '(ended_time) entry))
                      (cons :notes (let ((notes (reaper-alist-get '(notes) entry)))
                                     (if notes (decode-coding-string notes 'utf-8) ""))))))
             ;; API returns newest entry first. Simply reverse the list.
@@ -418,6 +420,21 @@ Stops any previously running timers."
          (new-time (reaper--time-to-hours-calculation (read-string "New time: " time)))
          (harvest-payload (make-hash-table :test 'equal)))
     (puthash "hours" new-time harvest-payload)
+    (reaper-api "PATCH" (format "time_entries/%s" entry-id) harvest-payload "Updated entry")
+    (reaper-refresh)))
+
+(defun reaper-edit-entry-start-end-time ()
+  "Edit start/end time of entry at point."
+  (interactive)
+  (let* ((entry-id (tabulated-list-get-id))
+         (entry (assoc entry-id reaper-timeentries))
+         (start-time (cdr (assoc :started_time entry)))
+         (new-start-time (read-string "New start time: " start-time))
+         (end-time (cdr (assoc :ended_time entry)))
+         (new-end-time (read-string "New end time: " end-time))
+         (harvest-payload (make-hash-table :test 'equal)))
+    (puthash "started_time" new-start-time harvest-payload)
+    (puthash "ended_time" new-end-time harvest-payload)
     (reaper-api "PATCH" (format "time_entries/%s" entry-id) harvest-payload "Updated entry")
     (reaper-refresh)))
 

--- a/reaper.el
+++ b/reaper.el
@@ -49,6 +49,12 @@
   :type 'string
   :group 'reaper)
 
+(defcustom reaper-hours-timer-mode t
+  "Defines if Harvest is configured to track time via duration.
+   Non-t value means Harvest is configured to track time via start and end time."
+  :type 'boolean
+  :group 'reaper)
+
 (defconst reaper--list-format
   [("Project" 32 nil)
    ("Task" 20 nil)
@@ -417,24 +423,14 @@ Stops any previously running timers."
          (entry (assoc entry-id reaper-timeentries))
          ;; If the timer is running add the time since the data was fetched.
          (time (reaper--hours-to-time (reaper--hours-accounting-for-running-timer entry)))
-         (new-time (reaper--time-to-hours-calculation (read-string "New time: " time)))
-         (harvest-payload (make-hash-table :test 'equal)))
-    (puthash "hours" new-time harvest-payload)
-    (reaper-api "PATCH" (format "time_entries/%s" entry-id) harvest-payload "Updated entry")
-    (reaper-refresh)))
-
-(defun reaper-edit-entry-start-end-time ()
-  "Edit start/end time of entry at point."
-  (interactive)
-  (let* ((entry-id (tabulated-list-get-id))
-         (entry (assoc entry-id reaper-timeentries))
          (start-time (cdr (assoc :started_time entry)))
-         (new-start-time (read-string "New start time: " start-time))
          (end-time (cdr (assoc :ended_time entry)))
-         (new-end-time (read-string "New end time: " end-time))
          (harvest-payload (make-hash-table :test 'equal)))
-    (puthash "started_time" new-start-time harvest-payload)
-    (puthash "ended_time" new-end-time harvest-payload)
+    (if reaper-hours-timer-mode
+        (puthash "hours" (reaper--time-to-hours-calculation (read-string "New time: " time)) harvest-payload)
+      (progn
+        (puthash "started_time" (read-string "New start time: " start-time) harvest-payload)
+        (puthash "ended_time" (read-string "New end time: " end-time) harvest-payload)))
     (reaper-api "PATCH" (format "time_entries/%s" entry-id) harvest-payload "Updated entry")
     (reaper-refresh)))
 


### PR DESCRIPTION
Opening [PR] again. To summarize  you don't want to have a variable `reaper-hours-timer-mode` but instead you want to automatically define what mode user is in, right? Also you want to update `reaper--list-format` based on mode, correct?

[PR]: https://github.com/xendk/reaper/pull/4